### PR TITLE
sdl: Build SDL_config.h to the same directory

### DIFF
--- a/SDL2-2.0.8/CMakeLists.txt
+++ b/SDL2-2.0.8/CMakeLists.txt
@@ -1584,8 +1584,9 @@ endif()
 #   endif()
 # endif()
 
+# Build to the same directory so that including SDL_config.h resolves.
 configure_file("${SDL2_SOURCE_DIR}/include/SDL_config.h.cmake"
-  "${SDL2_BINARY_DIR}/include/SDL_config.h")
+  "${SDL2_SOURCE_DIR}/include/SDL_config.h")
 
 # Prepare the flags and remove duplicates
 if(EXTRA_LDFLAGS)


### PR DESCRIPTION
This fixes the include being build in a different directory when using cmake from a different path.